### PR TITLE
Bugfix with -g setting

### DIFF
--- a/scalers.sh
+++ b/scalers.sh
@@ -28,7 +28,7 @@ while test $# -gt 0; do
     -g)
       case "$2" in
         ""|-*) echo "no parameter for $1" ; exit 1 ;;
-        *) geometry=$2 ; shift ;;
+        *) geometry=$2 ;;
       esac ; shift ;;
     -t)
       case "$2" in


### PR DESCRIPTION
It would shift one argument too far, for example -g 300x300 -s "haasnsoft" would give you
internal error at haasnsoft
